### PR TITLE
add timeout config and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ composer require asundust/auth-captcha
 // 'host' => env('AUTH_CAPTCHA_HOST'), // 部分需要此第三个参数！！！
 // 'domain' => env('AUTH_CAPTCHA_DOMAIN'), // 部分需要此第三个参数！！！
 // 'score' => env('AUTH_CAPTCHA_SCORE'), // 部分需要此第三个参数！！！
+// 'timeout' => env('AUTH_CAPTCHA_TIMEOUT'), // 如果部分出现超时500可以修改此参数，默认5
 // 'xxxxxx' => env('AUTH_CAPTCHA_XXXXXX'), // demo
 ```
 

--- a/src/Http/Controllers/AuthCaptchaController.php
+++ b/src/Http/Controllers/AuthCaptchaController.php
@@ -721,7 +721,7 @@ class AuthCaptchaController extends BaseAuthController
     private function captchaHttp()
     {
         return new Client([
-            'timeout' => 5,
+            'timeout' => config('admin.extensions.auth-captcha.timeout', 5),
             'verify' => false,
             'http_errors' => false,
         ]);


### PR DESCRIPTION
It is highly unlikely foreign hosts like `https://recaptcha.net` can return a response in 5 seconds, and straightly making `timeout` higher is not a best practice. So we propose adding a new config `admin.extensions.auth-captcha.timeout`, defaulting it `5` seconds thus developers can change it based on circumstances accordingly.

This is an awesome project, thank you for your contribution to the open-source community.